### PR TITLE
Fix minion bug

### DIFF
--- a/contracts/Moloch.sol
+++ b/contracts/Moloch.sol
@@ -57,7 +57,7 @@ contract Moloch is ReentrancyGuard {
     address public constant GUILD = address(0xdead);
     address public constant ESCROW = address(0xbeef);
     address public constant TOTAL = address(0xbabe);
-    address public constant minion; // address executing member governance updates
+    address public minion; // address executing member governance updates
     mapping (address => mapping(address => uint256)) public userTokenBalances; // userTokenBalances[userAddress][tokenAddress]
 
     enum Vote {


### PR DESCRIPTION
Getting a bug when Minion is set to a public constant. Contract compiles if you just set Minion to a public variable like the other variables set in the constructor. Might be a good way to be able to update the minion via vote too.