### PR TITLE
Last MakeSummoningTribute Patch

### DIFF
--- a/contracts/Moloch.sol
+++ b/contracts/Moloch.sol
@@ -189,6 +189,7 @@ contract Moloch is ReentrancyGuard {
     function makeSummoningTribute(uint256 tribute) public onlyMember {
         require(now < summoningTermination, "summoning terminated");
         require(IERC20(depositToken).transferFrom(msg.sender, address(this), tribute), "tribute failed");
+        require(members[msg.sender].shares <= 1, "this is a one time function");
         
         unsafeAddToBalance(GUILD, depositToken, tribute);
         


### PR DESCRIPTION
Added a requirement that caller can't have more than 1 share, which should restrict summoners from using this function multiple times.