### PR TITLE
Collect Token Cleanup

### DIFF
--- a/contracts/Moloch.sol
+++ b/contracts/Moloch.sol
@@ -656,14 +656,14 @@ contract Moloch is ReentrancyGuard {
         emit Withdraw(msg.sender, token, amount);
     }
 
-    function collectTokens(address token) external onlyDelegate {
+    // Can be used for payments or to collect whitelisted tokens sent to the DAO 
+    function collectTokens(address token) external  {
         uint256 amountToCollect = IERC20(token).balanceOf(address(this)) - userTokenBalances[TOTAL][token];
-        // only collect if 1) there are tokens to collect 2) token is whitelisted 3) token has non-zero balance
+        // only collect if 1) there are tokens to collect and 2) token is whitelisted
         require(amountToCollect > 0, "no tokens");
         require(tokenWhitelist[token], "not whitelisted");
-        require(userTokenBalances[GUILD][token] > 0, "no guild balance");
         
-        if (userTokenBalances[GUILD][token] == 0) {totalGuildBankTokens += 1;}
+        if (userTokenBalances[GUILD][token] == 0 && totalGuildBankTokens < MAX_TOKEN_GUILDBANK_COUNT) {totalGuildBankTokens += 1;}
         unsafeAddToBalance(GUILD, token, amountToCollect);
 
         emit TokensCollected(token, amountToCollect);

--- a/contracts/Moloch.sol
+++ b/contracts/Moloch.sol
@@ -656,8 +656,8 @@ contract Moloch is ReentrancyGuard {
         emit Withdraw(msg.sender, token, amount);
     }
 
-    // Can be used for payments or to collect whitelisted tokens sent to the DAO 
-    function collectTokens(address token) external  {
+    // can be used for payments or to collect whitelisted tokens sent to the DAO 
+    function collectTokens(address token) external {
         uint256 amountToCollect = IERC20(token).balanceOf(address(this)) - userTokenBalances[TOTAL][token];
         // only collect if 1) there are tokens to collect and 2) token is whitelisted
         require(amountToCollect > 0, "no tokens");
@@ -849,7 +849,7 @@ contract Moloch is ReentrancyGuard {
             
         require(totalShares <= MAX_GUILD_BOUND, "guild maxed");
 
-        if (userTokenBalances[GUILD][wrapperToken] == 0) {totalGuildBankTokens += 1;}
+        if (userTokenBalances[GUILD][wrapperToken] == 0 && totalGuildBankTokens < MAX_TOKEN_GUILDBANK_COUNT) {totalGuildBankTokens += 1;}
         unsafeAddToBalance(GUILD, wrapperToken, amount);
     }
     


### PR DESCRIPTION
Removed a require function from the collectTokens function that no longer made sense, given we can add tokens to the guild bank assuming. Also added a check that, if the whitelisted token has a zero balance, adding it won't cause the total guild tokens to exceed the max. Also removed the onlyDelegate modifier, so that it could be used for payments.